### PR TITLE
Updated README and setup files for Win and Mac

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ Common repository for The Sound of AI Open Source Research and instructions for 
 ## Global Requirements
 Csound https://csound.com/download.html
 
+On MacOs, if homebrew is installed, the setup script will install Csound automatically.
+
 Python 3.8
 
 ## First Step (All OS)

--- a/run.sh
+++ b/run.sh
@@ -1,2 +1,2 @@
-./rg_speech_to_text.sh
-./rg_production.sh
+./rg_speech_to_text/run.sh
+./rg_production/run.sh

--- a/run_mac.sh
+++ b/run_mac.sh
@@ -1,0 +1,10 @@
+#run all the modules
+./rg_speech_to_text/run_mac.sh & ./rg_text_to_sound/run_server_mac.sh & ./rg_sound_generation/run_mac.sh & ./rg_production/run_mac.sh 
+
+# get pid for processes on 8787 8786 8080
+# kill them
+kill $(lsof -t -i:8787)
+kill $(lsof -t -i:8786)
+kill $(lsof -t -i:8080)
+
+

--- a/setup.bat
+++ b/setup.bat
@@ -9,6 +9,7 @@ cd rg_sound_generation\sound_generator
 python -m venv venv
 venv\Scripts\python -m pip install --upgrade pip setuptools
 venv\Scripts\python -m pip install -r requirements.txt
+python sound_generator\download_checkpoints.py
 cd ..\..
 cd rg_production
 python -m venv venv

--- a/setup_mac.sh
+++ b/setup_mac.sh
@@ -14,7 +14,7 @@ cd rg_sound_generation
 python3 -m venv venv
 venv/bin/python -m pip install --upgrade pip setuptools
 venv/bin/python -m pip install -r sound_generator/requirements.txt
-cd ../..
+cd ..
 cd rg_production
 python3 -m venv venv
 venv/bin/python -m pip install --upgrade pip setuptools

--- a/setup_mac.sh
+++ b/setup_mac.sh
@@ -1,0 +1,22 @@
+cd rg_speech_to_text
+python3 -m venv venv
+venv/bin/python -m pip install --upgrade pip setuptools
+venv/bin/python -m pip install torch==1.7.1 torchvision==0.8.2 torchaudio==0.7.2
+venv/bin/python -m pip install -r requirements-linux.txt
+cd ..
+cd rg_text_to_sound
+python3 -m venv venv
+venv/bin/python -m pip install --upgrade pip setuptools
+venv/bin/python -m pip install rgws
+venv/bin/python -m pip install git+https://github.com/TheSoundOfAIOSR/rg_text_to_sound.git\#"subdirectory=tts_pipeline"
+cd ..
+cd rg_sound_generation
+python3 -m venv venv
+venv/bin/python -m pip install --upgrade pip setuptools
+venv/bin/python -m pip install -r sound_generator/requirements.txt
+cd ../..
+cd rg_production
+python3 -m venv venv
+venv/bin/python -m pip install --upgrade pip setuptools
+venv/bin/python -m pip install -r requirements.txt
+cd ..

--- a/setup_mac.sh
+++ b/setup_mac.sh
@@ -14,7 +14,9 @@ cd rg_sound_generation
 python3 -m venv venv
 venv/bin/python -m pip install --upgrade pip setuptools
 venv/bin/python -m pip install -r sound_generator/requirements.txt
+python3 sound_generator/sound_generator/download_checkpoints.py
 cd ..
+brew install csound
 cd rg_production
 python3 -m venv venv
 venv/bin/python -m pip install --upgrade pip setuptools


### PR DESCRIPTION
- Updated README,
- Added to setup.bat and setup_mac.sh script to download checkpoints for rg_sound_generation

Setup_mac.sh:

- fixed a bug that installed venv for rg_production in the wrong location
- added csound installation with homebrew

Setup.bat:

- Removed docker, substituted with WSL for rg_text_to_sound