### PR TITLE
Explicit Python 3.8 for Mac + added echo lines

### DIFF
--- a/setup_mac.sh
+++ b/setup_mac.sh
@@ -1,21 +1,25 @@
+echo "1/4 Installing Speech to text"
 cd rg_speech_to_text
 python3 -m venv venv
 venv/bin/python -m pip install --upgrade pip setuptools
 venv/bin/python -m pip install torch==1.7.1 torchvision==0.8.2 torchaudio==0.7.2
 venv/bin/python -m pip install -r requirements-linux.txt
 cd ..
+echo "2/4 Installing Text to sound"
 cd rg_text_to_sound
 python3 -m venv venv
 venv/bin/python -m pip install --upgrade pip setuptools
 venv/bin/python -m pip install rgws
 venv/bin/python -m pip install git+https://github.com/TheSoundOfAIOSR/rg_text_to_sound.git\#"subdirectory=tts_pipeline"
 cd ..
+echo "3/4 Installing Sound Generation"
 cd rg_sound_generation
 python3 -m venv venv
 venv/bin/python -m pip install --upgrade pip setuptools
 venv/bin/python -m pip install -r sound_generator/requirements.txt
 python3 sound_generator/sound_generator/download_checkpoints.py
 cd ..
+echo "4/4 Installing Production"
 brew install csound
 cd rg_production
 python3 -m venv venv

--- a/setup_mac.sh
+++ b/setup_mac.sh
@@ -1,20 +1,20 @@
 echo "1/4 Installing Speech to text"
 cd rg_speech_to_text
-python3 -m venv venv
+python3.8 -m venv venv
 venv/bin/python -m pip install --upgrade pip setuptools
 venv/bin/python -m pip install torch==1.7.1 torchvision==0.8.2 torchaudio==0.7.2
 venv/bin/python -m pip install -r requirements-linux.txt
 cd ..
 echo "2/4 Installing Text to sound"
 cd rg_text_to_sound
-python3 -m venv venv
+python3.8 -m venv venv
 venv/bin/python -m pip install --upgrade pip setuptools
 venv/bin/python -m pip install rgws
 venv/bin/python -m pip install git+https://github.com/TheSoundOfAIOSR/rg_text_to_sound.git\#"subdirectory=tts_pipeline"
 cd ..
 echo "3/4 Installing Sound Generation"
 cd rg_sound_generation
-python3 -m venv venv
+python3.8 -m venv venv
 venv/bin/python -m pip install --upgrade pip setuptools
 venv/bin/python -m pip install -r sound_generator/requirements.txt
 python3 sound_generator/sound_generator/download_checkpoints.py
@@ -22,7 +22,7 @@ cd ..
 echo "4/4 Installing Production"
 brew install csound
 cd rg_production
-python3 -m venv venv
+python3.8 -m venv venv
 venv/bin/python -m pip install --upgrade pip setuptools
 venv/bin/python -m pip install -r requirements.txt
 cd ..


### PR DESCRIPTION
Explicit Python 3.8 for Mac 
added echo lines as in the windows script