### PR TITLE
sound_gen venv now created in root directory

### DIFF
--- a/setup_mac.sh
+++ b/setup_mac.sh
@@ -17,7 +17,7 @@ cd rg_sound_generation
 python3.8 -m venv venv
 venv/bin/python -m pip install --upgrade pip setuptools
 venv/bin/python -m pip install -r ./timbre_conditioned_vae/requirements.txt
-cd ../..
+cd ..
 echo "4/4 Installing Production"
 brew install csound
 cd rg_production

--- a/setup_mac.sh
+++ b/setup_mac.sh
@@ -13,10 +13,10 @@ venv/bin/python -m pip install rgws
 venv/bin/python -m pip install git+https://github.com/TheSoundOfAIOSR/rg_text_to_sound.git\#"subdirectory=tts_pipeline"
 cd ..
 echo "3/4 Installing Sound Generation"
-cd rg_sound_generation/timbre_conditioned_vae
+cd rg_sound_generation
 python3.8 -m venv venv
 venv/bin/python -m pip install --upgrade pip setuptools
-venv/bin/python -m pip install -r requirements.txt
+venv/bin/python -m pip install -r ./timbre_conditioned_vae/requirements.txt
 cd ../..
 echo "4/4 Installing Production"
 brew install csound


### PR DESCRIPTION
The environment for sound gen was being created inside the timbre conditioned VAE instead of the root directory of the repo, creating conflicts on run (basically the run script was looking for an env in root, but I was installing the env in timbre_conditioned_vae ... ooops!). Now it's created in the root directory of rg_sound_generation to be more consistent with all the other rgs and not fail to run 