### PR TITLE
fix for #53 on the Mac side

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ cd project_common
 bash setup_mac.sh
 bash run_mac.sh
 ```
+If python3.8 is linked as `python3.8` rather than `python3`, please run `setup_mac38.sh` instead.
 
 ### Linux
 ```

--- a/README.md
+++ b/README.md
@@ -18,6 +18,13 @@ If you encounter any issues running or installing the app, please check if there
 
 On MacOs, if homebrew is installed, the setup script will install Csound automatically.
 
+### Portaudio
+* Portaudio http://portaudio.com/
+
+On Windows the setup script will install Portaudio.
+On MacOs, if homebrew is installed, the setup script will install Portaudio automatically.
+
+
 ### Python
 * Python version 3.8 is to be used
 * in case python 3.8 available on the system but not the default one then use `setup3.8.bat` instead of `setup.bat`

--- a/setup_mac.sh
+++ b/setup_mac.sh
@@ -1,5 +1,6 @@
 python3 utils/check_version.py || exit
 echo "1/4 Installing Speech to text"
+brew install portaudio
 cd rg_speech_to_text
 python3 -m venv venv
 venv/bin/python -m pip install --upgrade pip setuptools

--- a/setup_mac38.sh
+++ b/setup_mac38.sh
@@ -1,0 +1,31 @@
+python3.8 utils/check_version.py || exit
+echo "1/4 Installing Speech to text"
+brew install portaudio
+cd rg_speech_to_text
+python3.8 -m venv venv
+venv/bin/python -m pip install --upgrade pip setuptools
+venv/bin/python -m pip install torch==1.7.1 torchvision==0.8.2 torchaudio==0.7.2
+venv/bin/python -m pip install -r requirements-linux.txt
+cd ..
+echo "2/4 Installing Text to sound"
+cd rg_text_to_sound
+python3.8 -m venv venv
+venv/bin/python -m pip install --upgrade pip setuptools
+venv/bin/python -m pip install -r tts_websocketserver/requirements.txt
+cd tts_websocketserver/src
+../../venv/bin/python -m tts_websocketserver.initialize
+cd ../..
+cd ..
+echo "3/4 Installing Sound Generation"
+cd ./rg_sound_generation
+python3.8 -m venv venv
+venv/bin/python -m pip install --upgrade pip setuptools
+venv/bin/python -m pip install -r requirements.txt
+cd ..
+echo "4/4 Installing Production"
+brew install csound
+cd rg_production
+python3.8 -m venv venv
+venv/bin/python -m pip install --upgrade pip setuptools
+venv/bin/python -m pip install -r requirements.txt
+cd ..


### PR DESCRIPTION
Portaudio was not listed as a dependency and only installed automatically on windows, not on mac. Added documentation and modified mac script. We should do the same for Linux eventually